### PR TITLE
feat: change image to scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,10 @@ RUN apk update && \
 # Build Go binary
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-w -s" -o kyverno-notation-aws .
 
-FROM amd64/alpine:3.18
+FROM scratch
 WORKDIR /
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Notation home
 ENV PLUGINS_DIR=/plugins

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_PLATFORM="linux/amd64"
-ARG BUILDER_IMAGE="golang:1.19"
+ARG BUILDER_IMAGE="golang:1.20.6-alpine3.18"
 
 FROM --platform=$BUILD_PLATFORM $BUILDER_IMAGE as builder
 
@@ -10,15 +10,15 @@ COPY . ./
 ARG SIGNER_BINARY_LINK="https://d2hvyiie56hcat.cloudfront.net/linux/amd64/plugin/latest/notation-aws-signer-plugin.zip"
 ARG SIGNER_BINARY_FILE="notation-aws-signer-plugin.zip"
 RUN wget -O ${SIGNER_BINARY_FILE} ${SIGNER_BINARY_LINK} 
-RUN apt-get -y update && \
-    apt-get -y install unzip && \
+RUN apk update && \
+    apk add unzip && \
     unzip -o ${SIGNER_BINARY_FILE}
 
 # Build Go binary
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o kyverno-notation-aws .
 
-FROM amd64/amazonlinux:2.0.20230207.0
-RUN yum install tree -y
+FROM amd64/alpine:3.18
+RUN apk add tree
 WORKDIR /
 
 # Notation home

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,9 @@ RUN apk update && \
     unzip -o ${SIGNER_BINARY_FILE}
 
 # Build Go binary
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o kyverno-notation-aws .
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-w -s" -o kyverno-notation-aws .
 
 FROM amd64/alpine:3.18
-RUN apk add tree
 WORKDIR /
 
 # Notation home


### PR DESCRIPTION
Updating the base to alpine 3.18 reduces the size of image from 583.97MB to 79.2MB

<img width="651" alt="Size comparision between amazon linux image and alpine image" src="https://github.com/nirmata/kyverno-notation-aws/assets/72007651/541e5484-c8ab-4fa2-a632-1628d418d094">


Image verification is working as intended on main.
```bash
$ kubectl apply -f configs/samples/kyverno-policy.yaml
clusterpolicy.kyverno.io/check-images configured
$ kubectl -n test-notation run test --image=844333597536.dkr.ecr.us-west-2.amazonaws.com/kyverno-demo:v1 --dry-run=server
pod/test created (server dry run)
$ kubectl -n test-notation run test --image=844333597536.dkr.ecr.us-west-2.amazonaws.com/kyverno-demo:v1-unsigned --dry-run=server
Error from server: admission webhook "validate.kyverno.svc-fail" denied the request: 

resource Pod/test-notation/test was blocked due to the following policies 

check-images:
  call-aws-signer-extension: 'failed to check deny conditions: failed to substitute
    variables in condition key: failed to resolve result.verified at path : JMESPath
    query failed: Unknown key "result" in path'
```