### PR TITLE
Helm chart improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ notation-com.amazonaws.signer.notation.plugin_linux_amd64
 .DS_Store
 .tools
 coverage.txt
+/.idea/

--- a/charts/kyverno-notation-aws/templates/deployment.yaml
+++ b/charts/kyverno-notation-aws/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         runAsNonRoot: true
       serviceAccountName: {{ template "kyverno-notation-aws.serviceAccountName" . }}
       containers:
-      - image: ghcr.io/nirmata/kyverno-notation-aws:latest
+      - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: Always
         name: kyverno-notation-aws
         args:
@@ -74,6 +74,18 @@ spec:
         volumeMounts:
           - name: notation
             mountPath: /notation
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: notation
           emptyDir: {}

--- a/charts/kyverno-notation-aws/values.yaml
+++ b/charts/kyverno-notation-aws/values.yaml
@@ -7,6 +7,10 @@ fullnameOverride: ~
 # -- (string) Override the namespace the chart deploys to
 namespaceOverride: ~
 
+image:
+  repository: ghcr.io/nirmata/kyverno-notation-aws
+  tag: c6d5d94e638e36bd9c29ff0a78fbfa64b555d561
+
 # CRDs configuration
 crds:
 
@@ -50,5 +54,17 @@ serviceAccount:
 # Config map configuration
 configMap:
   
-  # -- The configmap name
-  name:
+  # -- The notation-plugin-config configmap name
+  name: notation-plugin-config
+
+# nodeSelector for extension Deployment. More details:
+# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
+nodeSelector: {}
+
+# tolerations for extension Deployment. More details:
+# https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+tolerations: []
+
+# affinity for extension Deployment. More details:
+# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}


### PR DESCRIPTION
Affinity, tolerations, nodeSelector support for helm chart, configmap name to align with current hardcoded [see issue related](https://github.com/nirmata/kyverno-notation-aws/issues/124#issuecomment-1902175459)


The ':latest' tag is mutable and can lead to unexpected errors if the image changes. A best practice is to use an immutable tag that maps to a specific version of an application Pod.
