### PR TITLE
chore: bump kyverno-notation-verifier version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,14 @@ go 1.21
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.24.7
+	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20230322223720-077b4a917a90
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-containerregistry v0.19.0
 	github.com/kyverno/kyverno v1.10.2
 	github.com/kyverno/pkg/certmanager v0.0.10
 	github.com/kyverno/pkg/tls v0.0.9
-	github.com/nirmata/kyverno-notation-verifier v1.0.2-0.20240311082313-f3a418fd7009
+	github.com/nirmata/kyverno-notation-verifier v1.0.2-0.20240503092559-230887462bf1
 	github.com/notaryproject/notation-core-go v1.0.2
 	github.com/pkg/errors v0.9.1
 	go.uber.org/zap v1.26.0
@@ -70,7 +71,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
-	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20230322223720-077b4a917a90 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1023,8 +1023,10 @@ github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nirmata/kyverno-notation-verifier v1.0.2-0.20240311082313-f3a418fd7009 h1:FrL8WWULeGqnJctmmO0sJ6yDruncRPijTKUj3TzjWc0=
-github.com/nirmata/kyverno-notation-verifier v1.0.2-0.20240311082313-f3a418fd7009/go.mod h1:LfI5AAZGleWLm5/fInN+bdv5/NukgxTPJSFCvob7Vhg=
+github.com/nirmata/kyverno-notation-verifier v1.0.2-0.20240429120510-295dd35eb2f7 h1:jooltuYFvGS/EUnwnoRnVAwBandn+PUSIwAsdfx6pf4=
+github.com/nirmata/kyverno-notation-verifier v1.0.2-0.20240429120510-295dd35eb2f7/go.mod h1:GjwSD0JxqFIfT+SvuOaVNEc0A10tgVULwv6imDCYWd4=
+github.com/nirmata/kyverno-notation-verifier v1.0.2-0.20240503092559-230887462bf1 h1:yarXLr1CKy0xkQDrJfMkoI8fogf/Xpkc12TFiigV4Sg=
+github.com/nirmata/kyverno-notation-verifier v1.0.2-0.20240503092559-230887462bf1/go.mod h1:GjwSD0JxqFIfT+SvuOaVNEc0A10tgVULwv6imDCYWd4=
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/nishanths/predeclared v0.0.0-20190419143655-18a43bb90ffc/go.mod h1:62PewwiQTlm/7Rj+cxVYqZvDIUc+JjZq6GHAC1fsObQ=
 github.com/nishanths/predeclared v0.2.1/go.mod h1:HvkGJcA3naj4lOwnFXFDkFxVtSqQMB9sbB1usJ+xjQE=

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"flag"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -13,7 +14,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
 	"github.com/go-logr/zapr"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/kyverno/kyverno/pkg/leaderelection"
 	"github.com/kyverno/pkg/certmanager"
 	tlsMgr "github.com/kyverno/pkg/tls"
@@ -195,7 +198,7 @@ func main() {
 		knvVerifier.WithPluginConfig(flagNotationPluginConfigMap),
 		knvVerifier.WithMaxSignatureAttempts(flagMaxSignatureAtempts),
 		knvVerifier.WithEnableDebug(flagEnableDebug),
-		knvVerifier.WithProviderAuthConfigResolver(getAuthFromIRSA),
+		knvVerifier.WithProviderKeychain(authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogger(io.Discard)))),
 		knvVerifier.WithTokenReviewEnabled(reviewKyvernoToken),
 		knvVerifier.WithCacheEnabled(cacheEnabled),
 		knvVerifier.WithMaxCacheSize(cacheMaxSize),


### PR DESCRIPTION
This PR adds the following
1. Adds support for EKS Pod Identity
2. Fixes: #166 
3. Fixes: #179