### PR TITLE
feat: add connection timeouts to the http server

### DIFF
--- a/main.go
+++ b/main.go
@@ -234,9 +234,13 @@ func main() {
 			},
 		}
 		srv := &http.Server{
-			Addr:      ":9443",
-			Handler:   mux,
-			TLSConfig: tlsConf,
+			Addr:              ":9443",
+			Handler:           mux,
+			TLSConfig:         tlsConf,
+			ReadTimeout:       30 * time.Second,
+			WriteTimeout:      30 * time.Second,
+			ReadHeaderTimeout: 30 * time.Second,
+			IdleTimeout:       1 * time.Minute,
 		}
 
 		go func() {


### PR DESCRIPTION
kyverno-notation-aws is not closing connections after responding, when the user restarts the  service, the collections are closed and memory drops significantly, This PR adds timeouts for server.

Slack Discussion: https://kubernetes.slack.com/archives/CLGR9BJU9/p1736307029363109