### PR TITLE
chore: Bump actions/upload-artifact to v4.6.2

### DIFF
--- a/.github/actions/publish-image/action.yaml
+++ b/.github/actions/publish-image/action.yaml
@@ -65,7 +65,7 @@ runs:
       with:
         version: v1
         args: app -licenses -json -output ${{ inputs.sbom-name }}-bom.cdx.json -main ${{ inputs.main-path }}
-    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.sbom-name }}-bom-cdx
         path: ${{ inputs.sbom-name }}-bom.cdx.json


### PR DESCRIPTION
# Description

This PR updates the `actions/upload-artifact` to `v4.6.2`  because the publishing step fails following its version's deprecation (cf: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions) : 

```
Error: This request has been automatically failed because it actions/upload-artifact: 0b7f8abb1508181956e8e162db84b466c27e18ce
``` 
