### PR TITLE
Update invalid operator in sample validate-policy.yaml

### DIFF
--- a/configs/samples/validate-policy.yaml
+++ b/configs/samples/validate-policy.yaml
@@ -55,5 +55,5 @@ spec:
         conditions:
           all:
           - key: "{{ response.verified }}"
-            operator: EQUALS
+            operator: Equals
             value: false


### PR DESCRIPTION
I was using this policy to get started with this project in existing Kyverno installations in existing clusters. Upon applying the policy the admission controller rejected it because the value for the operator wasn't valid.

```
admission webhook "validate-policy.kyverno.svc" denied the request: path: spec.rules[0].validate.deny.conditions.any[0].: entered value of `operator` is invalid. valid values: ["LessThan" "Equal" "AnyNotIn" "GreaterThanOrEquals" "NotEqual" "NotIn" "GreaterThan" "AnyIn" "DurationGreaterThan" "DurationLessThanOrEquals" "DurationLessThan" "Equals" "NotEquals" "In" "DurationGreaterThanOrEquals" "AllIn" "AllNotIn" "LessThanOrEquals"]
```

Changing this to `Equals` does the trick.