### PR TITLE
fix: Remove match-selector from test pod

### DIFF
--- a/charts/kyverno-notation-aws/templates/tests/_helpers.tpl
+++ b/charts/kyverno-notation-aws/templates/tests/_helpers.tpl
@@ -3,14 +3,6 @@
 {{- define "kyverno-notation-aws.test.labels" -}}
 {{- template "kyverno-notation-aws.labels.merge" (list
   (include "kyverno-notation-aws.labels.common" .)
-  (include "kyverno-notation-aws.test.matchLabels" .)
-  (include "kyverno-notation-aws.labels.component" "test")
-) -}}
-{{- end -}}
-
-{{- define "kyverno-notation-aws.test.matchLabels" -}}
-{{- template "kyverno-notation-aws.labels.merge" (list
-  (include "kyverno-notation-aws.matchLabels.common" .)
   (include "kyverno-notation-aws.labels.component" "test")
 ) -}}
 {{- end -}}

--- a/charts/kyverno-notation-aws/templates/tests/kyverno-notation-aws-liveness.yaml
+++ b/charts/kyverno-notation-aws/templates/tests/kyverno-notation-aws-liveness.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{ include "kyverno-notation-aws.test.labels" . | nindent 4 }}
   annotations:
-    {{- include "kyverno-notation-aws.test.annotations" . | nindent 4 }}
+    {{ include "kyverno-notation-aws.test.annotations" . | nindent 4 }}
 spec:
   automountServiceAccountToken: {{ .Values.test.automountServiceAccountToken }}
   restartPolicy: Never


### PR DESCRIPTION
## Description

Helm tests are flaky because the helm test pod is using the same match labels than the main pod, causing his request to be sometimes redirected to himself.

This PR removes `match-labels` usage in test-pods since we don't need it for now