### PR TITLE
fix: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           build-cache-key: build-images
       - name: Log into registry ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ghcr.io
           username: ${{github.actor}}

--- a/.github/workflows/image-publish.yaml
+++ b/.github/workflows/image-publish.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           build-cache-key: publish-images
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/nightly-scan.yaml
+++ b/.github/workflows/nightly-scan.yaml
@@ -39,14 +39,14 @@ jobs:
 
       - name: Scan image using grype
         id: grype-scan
-        uses: anchore/scan-action@v7
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7
         with:
           image: ${{ env.IMAGE_NAME }}
           severity-cutoff: low
           fail-build: true
 
       - name: Scan image using trivy
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # master
         id: trivy-scan
         with:
           image-ref: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           build-cache-key: publish-images
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
## Summary

Pins all GitHub Actions `uses:` references to full commit SHAs to prevent supply chain attacks via tag mutation.

### Changes
- `docker/login-action@v3 -> @c94ce9fb...`
- `docker/login-action@v3 -> @c94ce9fb...`
- `anchore/scan-action@v7 -> @e1165082...`
- `aquasecurity/trivy-action@master -> @57a97c7e...`
- `docker/login-action@v3 -> @c94ce9fb...`


### Why

Following the [TeamPCP/Checkmarx supply chain attack](https://thehackernews.com/2026/03/teampcp-hacks-checkmarx-github-actions.html), Nirmata is hardening all public repos against GitHub Actions tag hijacking. This repo was flagged as **CRITICAL** (unpinned actions + write permissions).

Tracked in: https://github.com/nirmata/platform-engineering-policies/issues/33
