### PR TITLE
fix: build signer plugin from source and fix chart deployment template bugs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,13 @@ COPY . ./
 
 ARG TARGETOS
 ARG TARGETARCH
-# Get Signer plugin binary
-ARG SIGNER_BINARY_LINK="https://d2hvyiie56hcat.cloudfront.net/linux/amd64/plugin/latest/notation-aws-signer-plugin.zip"
-ARG SIGNER_BINARY_FILE="notation-aws-signer-plugin.zip"
-RUN wget -O ${SIGNER_BINARY_FILE} ${SIGNER_BINARY_LINK} 
-RUN apk update && \
-    apk add unzip && \
-    unzip -o ${SIGNER_BINARY_FILE}
+# Build Signer plugin from source — the pre-built CDN binary bundles an outdated
+# AWS SDK that rejects the EKS Pod Identity endpoint (169.254.170.23).
+RUN apk add --no-cache git && \
+    git clone --depth 1 https://github.com/aws/aws-signer-notation-plugin.git /aws-signer-plugin && \
+    cd /aws-signer-plugin && \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -ldflags="-w -s" \
+      -o /notation-com.amazonaws.signer.notation.plugin ./cmd
 
 # Build Go binary
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-w -s" -o kyverno-notation-aws .

--- a/charts/kyverno-notation-aws/templates/deployment.yaml
+++ b/charts/kyverno-notation-aws/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: {{ template "kyverno-notation-aws.serviceAccountName" . }}
       containers:
       - image: {{ include "kyverno-notation-aws.image" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) | quote }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: kyverno-notation-aws
         args:
           - --debug
@@ -71,7 +71,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: AWS_REGION
-          value: {{ .Values.region }}
+          value: {{ .Values.region | quote }}
         - name: DEFAULT_TRUST_POLICY
           value: aws-signer-trust-policy
         {{- with .Values.startupProbe }}
@@ -80,11 +80,11 @@ spec:
         {{- end }}
         {{- with .Values.livenessProbe }}
         livenessProbe:
-          {{ tpl (toYaml .) $ | nindent 10 }}
+          {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}
         {{- with .Values.readinessProbe }}
         readinessProbe:
-          {{ tpl (toYaml .) $ | nindent 10 }}
+          {{- tpl (toYaml .) $ | nindent 10 }}
         {{- end }}
         volumeMounts:
           - name: notation


### PR DESCRIPTION
Summary

- Fix ARM64 builds: The Dockerfile hardcoded linux/amd64 in the AWS Signer plugin download URL, so ARM64 images shipped with the wrong binary architecture
- Fix EKS Pod Identity support: The pre-built signer plugin binary from the AWS CDN bundles an outdated AWS SDK that rejects the EKS Pod Identity endpoint (169.254.170.23) with "only loopback hosts are allowed".
Replaced the CDN download with a source build of github.com/aws/aws-signer-notation-plugin, which uses aws-sdk-go-v2 v1.41.0 with proper Pod Identity support
- Fix chart value region: AWS_REGION env var was rendered unquoted (value: {{ .Values.region }}), now uses | quote
- Fix imagePullPolicy ignored: Was hardcoded to Always, now uses .Values.image.pullPolicy (default IfNotPresent)
- Fix probe template whitespace: livenessProbe and readinessProbe blocks had extra blank lines due to missing {{- trim markers

Files changed

- Dockerfile — Build signer plugin from source instead of downloading pre-built binary (fixes ARM64 + Pod Identity)
- charts/kyverno-notation-aws/templates/deployment.yaml — Quote region value, respect imagePullPolicy from values, fix probe whitespace

Test plan

- helm template renders AWS_REGION as "eu-west-1" (quoted) with --set region=eu-west-1
- helm template renders imagePullPolicy: IfNotPresent (from values, no longer hardcoded Always)
- helm lint passes
- docker buildx build --platform linux/amd64 succeeds — plugin cloned, built with aws-sdk-go-v2/credentials v1.19.5, both binaries copied to final image
- docker buildx build --platform linux/arm64 succeeds (cross-compile)
- Deploy to EKS cluster with Pod Identity and verify signature verification works against 169.254.170.23