### PR TITLE
fix: cache ECR auth keychain to prevent memory leak + fix TTL overflow

### DIFF
--- a/cached_keychain.go
+++ b/cached_keychain.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+)
+
+const authCacheTTL = 6 * time.Hour
+
+type cachedAuth struct {
+	auth      *authn.AuthConfig
+	expiresAt time.Time
+}
+
+// cachedKeychain wraps an authn.Keychain and caches resolved credentials
+// per registry for a configurable TTL. This prevents creating new AWS SDK
+// sessions and ECR API calls on every image verification request, which
+// was causing goroutine/HTTP transport leaks leading to OOM.
+type cachedKeychain struct {
+	inner authn.Keychain
+	mu    sync.RWMutex
+	cache map[string]cachedAuth
+}
+
+func NewCachedKeychain(inner authn.Keychain) authn.Keychain {
+	return &cachedKeychain{
+		inner: inner,
+		cache: make(map[string]cachedAuth),
+	}
+}
+
+func (c *cachedKeychain) Resolve(target authn.Resource) (authn.Authenticator, error) {
+	key := target.RegistryStr()
+
+	c.mu.RLock()
+	if entry, ok := c.cache[key]; ok && time.Now().Before(entry.expiresAt) {
+		c.mu.RUnlock()
+		return authn.FromConfig(*entry.auth), nil
+	}
+	c.mu.RUnlock()
+
+	// Cache miss or expired — resolve from inner keychain
+	auth, err := c.inner.Resolve(target)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the auth config to cache it
+	authConfig, err := auth.Authorization()
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.cache[key] = cachedAuth{
+		auth:      authConfig,
+		expiresAt: time.Now().Add(authCacheTTL),
+	}
+	c.mu.Unlock()
+
+	return authn.FromConfig(*authConfig), nil
+}

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&cacheEnabled, "cacheEnabled", true, "Whether to use a TTL cache for storing verified images, default is true")
 	flag.Int64Var(&cacheMaxSize, "cacheMaxSize", 1000, "Max size limit for the TTL cache, default is 1000.")
-	flag.Int64Var(&cacheTTLDuration, "cacheTTLDurationSeconds", int64(1*time.Hour), "Max TTL value for a cache in seconds, default is 1 hour.")
+	flag.Int64Var(&cacheTTLDuration, "cacheTTLDurationSeconds", int64(time.Hour/time.Second), "Max TTL value for a cache in seconds, default is 1 hour.")
 	flag.BoolVar(&reviewKyvernoToken, "reviewKyvernoToken", true, "Checks if the Auth token in the request is a token from kyverno controllers or other allowed users, default is true.")
 	flag.StringVar(&allowedUsers, "allowedUsers", "system:serviceaccount:kyverno:kyverno-admission-controller,system:serviceaccount:kyverno:kyverno-reports-controller", "Comma-seperated list of all the allowed users and service accounts.")
 	flag.StringVar(&flagLogLevel, "logLevel", "info", "Log level: trace, debug, info, warn, error")
@@ -200,7 +200,7 @@ func main() {
 		knvVerifier.WithPluginConfig(flagNotationPluginConfigMap),
 		knvVerifier.WithMaxSignatureAttempts(flagMaxSignatureAtempts),
 		knvVerifier.WithEnableDebug(flagEnableDebug),
-		knvVerifier.WithProviderKeychain(authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogger(io.Discard)))),
+		knvVerifier.WithProviderKeychain(NewCachedKeychain(authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogger(io.Discard))))),
 		knvVerifier.WithTokenReviewEnabled(reviewKyvernoToken),
 		knvVerifier.WithCacheEnabled(cacheEnabled),
 		knvVerifier.WithMaxCacheSize(cacheMaxSize),


### PR DESCRIPTION
## Summary
- Cache ECR auth keychain to prevent memory leak causing OOM
- Fix `cacheTTLDurationSeconds` default value int64 overflow

## Root cause — memory leak
`authn.NewKeychainFromHelper(ecr.NewECRHelper(...))` creates a new AWS SDK session and calls `GetAuthorizationToken` on every image verification request. These sessions accumulate leaked HTTP transports and goroutines, causing pods to grow from ~30MB to multiple GBs before OOM-kill.

### Fix
Add a caching wrapper (`cached_keychain.go`) around the ECR keychain that reuses resolved auth tokens for 6 hours (ECR tokens are valid for 12h), eliminating per-request SDK session creation.

### Before
- Staging pods: 33MB → 8GB → OOMKilled → restart (780+ restarts in 11 days at 10Gi limit)
- Production pods: 33MB → 5-8GB → OOMKilled → restart

### After
- All pods stable at ~45-47MB after 4+ hours under normal traffic

## Root cause — TTL overflow
Default value `int64(1*time.Hour)` is in nanoseconds (3.6e12). Line 207 multiplies by `time.Second` (1e9), overflowing int64 (max ~9.2e18) and producing a garbage Duration. Fixed to `int64(time.Hour/time.Second)` = 3600.

## Files changed
- `cached_keychain.go` — new thread-safe caching wrapper with 6h TTL
- `main.go` — wrap ECR keychain with `NewCachedKeychain()` + fix default TTL

Fixes #482