### PR TITLE
feat: add replicaCount and topologySpreadConstraints to kyverno-notation-aws chart

### DIFF
--- a/charts/kyverno-notation-aws/README.md
+++ b/charts/kyverno-notation-aws/README.md
@@ -9,6 +9,7 @@ Kyverno extension service for Notation and the AWS signer
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | region | string | `"us-west-2"` |  |
+| replicaCount | int | `1` | Number of replicas for the Deployment |
 | nameOverride | string | `nil` | Override the name of the chart |
 | fullnameOverride | string | `nil` | Override the expanded name of the chart |
 | namespaceOverride | string | `nil` | Override the namespace the chart deploys to |
@@ -29,6 +30,8 @@ Kyverno extension service for Notation and the AWS signer
 | nodeSelector | object | `{}` |  |
 | tolerations | list | `[]` |  |
 | affinity | object | `{}` |  |
+| podAnnotations | object | `{}` | podAnnotations for extension Deployment pods. |
+| topologySpreadConstraints | list | `[]` | topologySpreadConstraints for extension Deployment. More details: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
 | customLabels | object | `{}` | user supplied labels to apply to all resources excluding label selectors |
 | startupProbe | object | See [values.yaml](values.yaml) | Startup probe. The block is directly forwarded into the deployment, so you can use whatever startupProbes configuration you want. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/ |
 | livenessProbe | object | See [values.yaml](values.yaml) | Liveness probe. The block is directly forwarded into the deployment, so you can use whatever livenessProbe configuration you want. ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/ |

--- a/charts/kyverno-notation-aws/templates/deployment.yaml
+++ b/charts/kyverno-notation-aws/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   progressDeadlineSeconds: 600
   revisionHistoryLimit: 10
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   {{- with .Values.deployment.updateStrategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
@@ -18,6 +18,10 @@ spec:
       {{- include "kyverno-notation-aws.matchLabels.common" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "kyverno-notation-aws.labels" . | nindent 8 }}
     spec:
@@ -99,6 +103,10 @@ spec:
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:

--- a/charts/kyverno-notation-aws/values.yaml
+++ b/charts/kyverno-notation-aws/values.yaml
@@ -1,5 +1,8 @@
 region: us-west-2
 
+# -- (int) Number of replicas for the Deployment
+replicaCount: 1
+
 # -- (string) Override the name of the chart
 nameOverride: ~
 
@@ -87,6 +90,13 @@ tolerations: []
 # affinity for extension Deployment. More details:
 # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
+
+# podAnnotations for extension Deployment pods.
+podAnnotations: {}
+
+# topologySpreadConstraints for extension Deployment. More details:
+# https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+topologySpreadConstraints: []
 
 # -- user supplied labels to apply to all resources excluding label selectors
 customLabels: {}


### PR DESCRIPTION
### Summary

Makes the number of replicas configurable and adds support for topologySpreadConstraints (and podAnnotations) to the kyverno-notation-aws Helm chart, which previously had replicas: 1 hardcoded in the template and no topology spread support.

What changed

- templates/deployment.yaml: replicas is now read from .Values.replicaCount (previously hardcoded to 1); added an optional annotations block on the pod template (.Values.podAnnotations) and an optional topologySpreadConstraints block on the pod spec (.Values.topologySpreadConstraints), following the same {{- with }} pattern already used for nodeSelector/affinity/tolerations.
- values.yaml: new keys replicaCount: 1, podAnnotations: {}, and topologySpreadConstraints: [].
- README.md: values table updated manually with the three new entries (helm-docs not available locally to regenerate).

Why

The chart didn't allow running more than one replica or configuring pod spread across zones/nodes, limiting its use in multi-AZ high-availability scenarios.

Additional context

Backward-compatible — defaults preserve current behavior. Validated via helm lint and helm template with default and overridden values.


References https://github.com/nirmata/kyverno-notation-aws/issues/459